### PR TITLE
clipboard option added to cli

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 'use strict';
+var cpypst = require('copy-paste');
 var meow = require('meow');
 var LessPass = require('lesspass');
 var read = require('read');
@@ -9,12 +10,13 @@ var cli = meow(`
       $ lesspass <site> <login> <masterPassword>
 
     Options
-        --lowercase, -l    true or false (default true)        
-        --uppercase, -u    true or false (default true)    
-        --symbols, -s      true or false (default true)    
-        --numbers, -n      true or false (default true)
-        --length, -L       int (default 12)
-        --counter, -c      int (default 1)
+        --lowercase, -l     true or false (default true)
+        --uppercase, -u     true or false (default true)
+        --symbols, -s       true or false (default true)
+        --numbers, -n       true or false (default true)
+        --clipboard, -C     true or false (default false)
+        --length, -L        int (default 12)
+        --counter, -c       int (default 1)
 
     Examples
       $ lesspass lesspass.com contact@lesspass.com 'my Master Password' --length=14 -s=false
@@ -27,12 +29,20 @@ var cli = meow(`
         n: 'numbers',
         L: 'length',
         c: 'counter',
+        C: 'clipboard',
     }
 });
 
 function calcPassword(site, login, masterPassword, options) {
     LessPass.generatePassword(site, login, masterPassword, options).then(generatedPassword => {
-        console.log(generatedPassword);
+        if (options.clipboard == true) {
+            cpypst.copy(generatedPassword);
+            console.log("Copied to clipboard");
+            process.exit();
+        } else {
+            console.log(generatedPassword);
+            process.exit();
+        }
     });
 }
 
@@ -40,13 +50,15 @@ var lowercase = (cli.flags.lowercase || 'true').toLowerCase() === 'true';
 var uppercase = (cli.flags.uppercase || 'true').toLowerCase() === 'true';
 var symbols = (cli.flags.symbols || 'true').toLowerCase() === 'true';
 var numbers = (cli.flags.numbers || 'true').toLowerCase() === 'true';
+var clipboard = (cli.flags.clipboard || 'false').toLowerCase() === 'true';
 var options = {
     counter: cli.flags.counter || 1,
     length: cli.flags.length || 16,
     lowercase: lowercase,
     uppercase: uppercase,
     numbers: numbers,
-    symbols: symbols
+    symbols: symbols,
+    clipboard: clipboard
 };
 
 var site = cli.input[0];

--- a/package.json
+++ b/package.json
@@ -21,9 +21,10 @@
     "test": "ava"
   },
   "dependencies": {
-    "lesspass": "^6.0.0",
-    "meow": "^3.3.0",
-    "read": "^1.0.7"
+    "copy-paste": "1.3.0",
+    "lesspass": "6.0.0",
+    "meow": "3.7.0",
+    "read": "1.0.7"
   },
   "devDependencies": {
     "ava": "^0.17.0",

--- a/readme.md
+++ b/readme.md
@@ -26,6 +26,7 @@ $ lesspass --help
       --uppercase, -u    true or false (default true)    
       --symbols, -s      true or false (default true)    
       --numbers, -n      true or false (default true)
+      --clipboard, -C    true or false (default false)
       --length, -L       int (default 12)
       --counter, -c      int (default 1)
 


### PR DESCRIPTION
This pull request solves issue <a href="https://github.com/lesspass/lesspass/issues/117">#117</a> (in the main repo).

The name of the option is `--clipboard` (short form `-C`), it is false by default.