### PR TITLE
[CLI] Exit cleanly on cancellation

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -119,6 +119,9 @@ if (cli.input.length === 3) {
   calcPassword(site, login, masterPassword, passwordProfile)
 } else {
   read({prompt: 'master password: ', silent: true}, function(er, password) {
+    if (er && er.message === 'canceled') {
+      process.exit();
+    }
     calcPassword(site, login, password, passwordProfile)
   });
 }


### PR DESCRIPTION
If I cancel with `Ctrl+C` when `lesspass` prompts me for the master
password, I get the following error:

    $ lesspass example.com test
    master password: TypeError: Pass phrase must be a buffer
        at pbkdf2 (crypto.js:643:20)
        at Object.exports.pbkdf2 (crypto.js:623:10)
        at /usr/local/lib/node_modules/lesspass-cli/node_modules/lesspass/src/pbkdf2.js:40:16
        at Promise (<anonymous>)
        at pbkdf2Browserified (/usr/local/lib/node_modules/lesspass-cli/node_modules/lesspass/src/pbkdf2.js:39:12)
        at calcEntropy (/usr/local/lib/node_modules/lesspass-cli/node_modules/lesspass/src/v2.js:23:12)
        at Object.generatePassword (/usr/local/lib/node_modules/lesspass-cli/node_modules/lesspass/src/v2.js:16:12)
        at Object.generatePassword (/usr/local/lib/node_modules/lesspass-cli/node_modules/lesspass/src/lesspass.js:61:15)
        at calcPassword (/usr/local/lib/node_modules/lesspass-cli/cli.js:51:12)
        at /usr/local/lib/node_modules/lesspass-cli/cli.js:122:5

This is a small fixe to catch the error and exit normally.